### PR TITLE
check if width has actually changed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,7 @@ export default class Ticker extends React.Component {
   }
 
   onResize = () => {
+    if (this.tickerRef.current.offsetWidth === this.state.width) return
     this.setState({
       ...getDefaultState(this.props.offset, this.tickerRef.current.offsetWidth),
       height: this.props.height


### PR DESCRIPTION
Hi!

Scrolling fires the `resize` event in iOS Safari (and maybe other mobile browsers, I'm not sure), causing the ticker to "restart". I added a check to only set state if the the tickers offsetWidth actually changed.

Thanks! ✌🏻