### PR TITLE
fix offsetWidth of null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -68,7 +68,7 @@ export default class Ticker extends React.Component {
   }
 
   onResize = () => {
-    if (this.tickerRef.current.offsetWidth === this.state.width) return
+    if (!this.tickerRef.current || this.tickerRef.current.offsetWidth === this.state.width) return
     this.setState({
       ...getDefaultState(this.props.offset, this.tickerRef.current.offsetWidth),
       height: this.props.height


### PR DESCRIPTION
Hey!

I’m using ticker in chrome fullscreen mode and after exiting fullscreen, onResize is getting called and this.tickerRef.current is null. So I added an additional guard to onResize method, that checks if this.tickerRef.current exists.