### PR TITLE
Adding types for onNext and onFinish

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,15 +1,15 @@
-import * as React from "react";
+import * as React from 'react'
 
 type Props = {
-  children: ({ index }: { index: number }) => React.ReactNode;
-  direction?: "toRight" | "toLeft";
-  mode?: "chain" | "await" | "smooth";
-  move?: boolean;
-  offset?: number | "run-in" | string;
-  speed?: number;
-  height?: number | string;
-  onNext?: (index: any) => void;
-  onFinish?: () => void;
-};
+  children: ({ index }: { index: number }) => React.ReactNode
+  direction?: "toRight" | "toLeft",
+  mode?: "chain" | "await" | "smooth",
+  move?: boolean,
+  offset?: number | "run-in" | string,
+  speed?: number,
+  height?: number | string,
+  onNext?: (index: any) => void,
+  onFinish?: () => void
+}
 
 export default class Ticker extends React.Component<Props> {}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,13 +1,15 @@
-import * as React from 'react'
+import * as React from "react";
 
 type Props = {
-  children: ({ index }: { index: number }) => React.ReactNode
-  direction?: "toRight" | "toLeft",
-  mode?: "chain" | "await" | "smooth",
-  move?: boolean,
-  offset?: number | "run-in" | string,
-  speed?: number,
-  height?: number | string
-}
+  children: ({ index }: { index: number }) => React.ReactNode;
+  direction?: "toRight" | "toLeft";
+  mode?: "chain" | "await" | "smooth";
+  move?: boolean;
+  offset?: number | "run-in" | string;
+  speed?: number;
+  height?: number | string;
+  onNext?: (index: any) => void;
+  onFinish?: () => void;
+};
 
 export default class Ticker extends React.Component<Props> {}


### PR DESCRIPTION
I have added typing for onNext and onFinish props so typescript would not show errors when the package is used with typescript with passing props of either onNext or onFinish.
